### PR TITLE
use Wire.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ include
 lib
 test
 build.log
+CMakeLists.txt
+CMakeListsPrivate.txt
+cmake-build-*
+.idea
+platformio_override.ini

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,14 +8,16 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
+[platformio]
+extra_configs = platformio_override.ini
+
 [env:ATtiny85]
 platform = atmelavr
 board = attiny85
 framework = arduino
 
 lib_deps =
-  PinChangeInterrupt@1.2.6
-  TinyWireSio
+    PinChangeInterrupt@1.2.6
 
 board_build.f_cpu = 8000000L
 board_fuses.lfuse = 0xE2

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -1,0 +1,4 @@
+[env:ATtiny85]
+upload_port =
+upload_flags =
+upload_protocol = usbtiny


### PR DESCRIPTION
I'm trying to interface your attiny-i2c-fan-controller firmware with Tasmota but it seems that the TinyWireSio library is not working as it should.
If I use your original firmware, the ATtiny85 doesn't talk to any ESP8266 that I try to connect to via I2C.
So, I tryed replacing TinyWireS with "Wire.h" and everything is ok.
Do you see any problems using Wire.h instead of TinyWireS?

I also added to the code some features to work with CLion and its Platformio plugin.